### PR TITLE
Add CTA feature: Show Up

### DIFF
--- a/.vuepress/components/Home/Cta.vue
+++ b/.vuepress/components/Home/Cta.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="config" class="cta-main">
+    <h3>{{ config.title }}</h3>
+    <p>{{ config.description }}</p>
+    <Button
+      class="cta-main_button"
+      :buttonText="config.url.text"
+      :to="this.config.url.link"
+    />
+  </div>
+</template>
+
+<script>
+import Button from "../Button.vue";
+import config from "../../config";
+
+export default {
+  components: { Button },
+  data() {
+    return {
+      config: config.cta,
+    };
+  },
+};
+</script>
+
+<style lang="stylus">
+@import '../../theme/styles/config.styl'
+
+.cta-main
+  color #fff
+  display flex
+  flex-direction column
+  align-items center
+  justify-content center
+  width 100%
+  margin-bottom 3rem
+
+  h3
+    font-size clamp(2rem, calc(-.875rem + 1.8vw),8.5rem)
+    line-height 28px
+    margin-bottom 1rem
+    max-width 55rem
+    text-align center
+
+  p
+    font-size clamp(1rem, calc(-.875rem + 1.8vw),8.5rem)
+    line-height 28px
+    max-width 55rem
+    text-align center
+    padding 0 1rem
+
+  &_button
+    padding-top 1rem
+
+</style>

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -7,6 +7,15 @@ module.exports = {
     "We're bringing the Ethereum community to Prague! This website allows anyone to add and update their side event happening around ETHPrague conference & hackathon.",
   calendarHeading: "June 2024",
   submitEventLink: "https://pwn.typeform.com/to/eLWbM6eS",
+  cta: {
+    title: "Organizing an event?",
+    description: "Show Up is an onchain RSVP and Event management protocol designed to reshape event participation. Increase event participation. Reward attendees.",
+    url: 
+    {
+      text: "Learn more",
+      link: "https://www.showup.events/",
+    },
+  },
   startDate: {
     day: 27,
     month: 5,

--- a/.vuepress/theme/Home.vue
+++ b/.vuepress/theme/Home.vue
@@ -4,6 +4,7 @@
     <Hero />
     <Venues />
     <Events />
+    <Cta />
   </div>
 </template>
 
@@ -15,9 +16,10 @@ import Events from "../components/Home/Events.vue";
 import Footer from "../components/Footer.vue";
 import Venues from "../components/Home/Venues.vue";
 import Banner from "../components/Home/Banner.vue";
+import Cta from "../components/Home/Cta.vue";
 
 export default {
-  components: { NavLink, Button, Hero, Footer, Venues, Events, Banner },
+  components: { NavLink, Button, Hero, Footer, Venues, Events, Banner, Cta },
 };
 </script>
 


### PR DESCRIPTION
As discussed with @JosefJ - proposing a new feature to add an additional CTA  
In this case to promote Show Up - a new onchain RSVP and event management protocol to increase event participation.
Could maybe build it out to a more dedicated partner page at some point.

But I wanted to submit this first :)

It adds a small CTA banner at the bottom of the mainpage.
![image](https://github.com/PWNFinance/gm_events_cities/assets/25974464/8148b6b0-50c7-4869-936d-9e331685fa47)

Open to feedback